### PR TITLE
Adds debugging and potentially fixes some flakiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN go install github.com/jstemmer/go-junit-report
 
 FROM registry.access.redhat.com/ubi9-minimal
 
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 RUN mkdir -p /config /result
 RUN chgrp -R 0 /result && chmod -R g=u /result
 WORKDIR /app
@@ -18,4 +19,3 @@ COPY --from=builder /image/bin/skupper-ocp-smoke-test .
 COPY --from=builder /go/bin/go-junit-report .
 COPY scripts/run-test.sh .
 CMD './run-test.sh'
-

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
-/app/skupper-ocp-smoke-test -test.v | tee /tmp/test.out
-cat /tmp/test.out | /app/go-junit-report | tee /result/junit.xml
+
+set -o pipefail
+/app/skupper-ocp-smoke-test -test.v | tee -i /tmp/test.out
+ret=$?
+
+/app/go-junit-report < /tmp/test.out | tee /result/junit.xml
+
+exit $ret


### PR DESCRIPTION
- Fixes `scripts/run-test.sh`, so it returns `/app/skupper-ocp-smoke-test` exit status, so Kube may retry it per backoffLimit
- Sets `testjob`'s backoffLimit to 10 by default; the skupper service may not be 100% operational by the first time the curl job runs
- Adds -v, -m 10 to curl command; helps debugging and avoids a single job run to consume the whole period allowed for retesting
- Shows `testjob`'s logs and `-o yaml` at the end of the execution